### PR TITLE
Handle slog.Attr correctly

### DIFF
--- a/logadapter.go
+++ b/logadapter.go
@@ -23,7 +23,8 @@ func (s *logAdapter) With(args ...interface{}) logger.Logger {
 }
 
 func (s *logAdapter) Debug(v ...interface{}) {
-	s.log.Debug(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Debug(msg, args...)
 }
 
 func (s *logAdapter) Debugf(format string, v ...interface{}) {
@@ -31,7 +32,8 @@ func (s *logAdapter) Debugf(format string, v ...interface{}) {
 }
 
 func (s *logAdapter) Info(v ...interface{}) {
-	s.log.Info(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Info(msg, args...)
 }
 
 func (s *logAdapter) Infof(format string, v ...interface{}) {
@@ -39,7 +41,8 @@ func (s *logAdapter) Infof(format string, v ...interface{}) {
 }
 
 func (s *logAdapter) Warn(v ...interface{}) {
-	s.log.Warn(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Warn(msg, args...)
 }
 
 func (s *logAdapter) Warnf(format string, v ...interface{}) {
@@ -47,7 +50,8 @@ func (s *logAdapter) Warnf(format string, v ...interface{}) {
 }
 
 func (s *logAdapter) Error(v ...interface{}) {
-	s.log.Error(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Error(msg, args...)
 }
 
 func (s *logAdapter) Errorf(format string, v ...interface{}) {
@@ -55,7 +59,8 @@ func (s *logAdapter) Errorf(format string, v ...interface{}) {
 }
 
 func (s *logAdapter) Fatal(v ...interface{}) {
-	s.log.Error(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Error(msg, args...)
 	os.Exit(1)
 }
 
@@ -65,13 +70,37 @@ func (s *logAdapter) Fatalf(format string, v ...interface{}) {
 }
 
 func (s *logAdapter) Print(v ...interface{}) {
-	s.log.Info(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Info(msg, args...)
 }
 
 func (s *logAdapter) Println(v ...interface{}) {
-	s.log.Info(fmt.Sprint(v...))
+	msg, args := getArgs(v...)
+	s.log.Info(msg, args...)
 }
 
 func (s *logAdapter) Printf(format string, v ...interface{}) {
 	s.log.Info(fmt.Sprintf(format, v...))
+}
+
+// getArgs returns the message and arguments from the variadic arguments.
+func getArgs(v ...interface{}) (string, []interface{}) {
+	if len(v) == 0 {
+		return "", nil
+	}
+	if len(v) == 1 {
+		return fmt.Sprint(v[0]), nil
+	}
+	// validate that the first argument is a string
+	msg, ok := v[0].(string)
+	if !ok {
+		return fmt.Sprint(v...), nil
+	}
+	// validate that the rest of the arguments are Attr
+	for i := 1; i < len(v); i++ {
+		if _, ok := v[i].(slog.Attr); !ok {
+			return fmt.Sprint(v...), nil
+		}
+	}
+	return msg, v[1:]
 }

--- a/logadapter_test.go
+++ b/logadapter_test.go
@@ -3,15 +3,19 @@ package logadapter
 import (
 	"errors"
 	"log/slog"
+	"os"
 	"testing"
 )
 
 func TestLogadapter(t *testing.T) {
-	log := LogAdapter(slog.Default())
+	log := LogAdapter(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
 	log.Info("hi")
 	log.With("err", errors.New("uh oh"), "ps", "test", "num", 123).Warn("warnnn..")
 	log.Info("yes")
 
 	log.Warnf("failed due to %v", errors.New("uh oh"))
+	log.Info()
+	log.Info("done", "key", "value", "num", 123)
+	log.Info("done", slog.String("key", "value"), slog.Int("num", 123))
 }


### PR DESCRIPTION
Using `Sprint(args...)` with slog leads to this results:
```go
log.Info("message", slog.String("a", "b"), slog.String("c", "d"))
// output: {"time":"2009-11-10T23:00:00Z","level":"INFO","msg":"messagea=b c=d"}
```
While we would expect it to behave as this:
```go
log.With(slog.String("a", "b"), slog.String("c", "d")).Info("message")
// output: {"time":"2009-11-10T23:00:00Z","level":"INFO","msg":"message","a":"b","c":"d"}
```

This PR checks that the first argument is a `string` and the rest of the arguments are `slog.Attr` and makes sure that the output is the same as example #2